### PR TITLE
Documentation hosted on Read the Docs

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -12,6 +12,7 @@ how to :ref:`installation` the project.
 .. note::
 
    This project is under active development.
+   Lumache has its documentation hosted on Read the Docs.
 
 Contents
 --------


### PR DESCRIPTION
A line "Lumache has its documentation hosted on Read the Docs." is added to the project.